### PR TITLE
The tree doesn't display correctly in IE 8 because of this useless quote...

### DIFF
--- a/jquery.easytree.js
+++ b/jquery.easytree.js
@@ -723,7 +723,7 @@
             var forceOpenNode = level < _settings.minOpenLevels;
 
             var ulStyle = level == 0 || display || forceOpenNode ? "" : " style='display:none' ";
-            html += '<ul tabindex="0" class="' + ulCss + '" ' + ulStyle + '">';
+            html += '<ul tabindex="0" class="' + ulCss + '" ' + ulStyle + '>';
 
             for (i = 0; i < nodes.length; i++) {
                 var n = nodes[i];


### PR DESCRIPTION
I've tried on your website and the problem is the same.

With this little fix, it'll display correctly with chrome, firefox, IE 11 as well as IE 8, IE 9 and IE 10.
